### PR TITLE
【機能追加サンプル】Githubのリポジトリの詳細画面にブランチ情報を追加

### DIFF
--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		5ABB0BDD2308FE470072660A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABB0BDC2308FE470072660A /* LoadingView.swift */; };
 		5ABB0BDF2308FE520072660A /* LoadingView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5ABB0BDE2308FE520072660A /* LoadingView.xib */; };
 		5ACA090A234880E8001B4D73 /* BranchesData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA0909234880E8001B4D73 /* BranchesData.swift */; };
+		5ACA090C2348836F001B4D73 /* BranchesRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -161,6 +162,7 @@
 		5ABB0BDC2308FE470072660A /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		5ABB0BDE2308FE520072660A /* LoadingView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingView.xib; sourceTree = "<group>"; };
 		5ACA0909234880E8001B4D73 /* BranchesData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesData.swift; sourceTree = "<group>"; };
+		5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRequestClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -418,6 +420,7 @@
 				5A662C5823083F9500BD0403 /* CollaboratorsClient.swift */,
 				5A662C5A23083FC200BD0403 /* CommunityProfileClient.swift */,
 				5ABAAC10231B9B9000AF76A7 /* GitHubAPIRequestable.swift */,
+				5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */,
 			);
 			path = APIRequestClient;
 			sourceTree = "<group>";
@@ -652,6 +655,7 @@
 				5AB6D67022F5419A008C3D14 /* Displayable.swift in Sources */,
 				5A4CBEBB2308CAA30056E710 /* CollaboratorDisplayData.swift in Sources */,
 				5AADA61C22EC1F47001BA1AD /* NSObject+Additions.swift in Sources */,
+				5ACA090C2348836F001B4D73 /* BranchesRequestClient.swift in Sources */,
 				5A667EA723129FF900C8E190 /* CollaboratorRepository.swift in Sources */,
 				5A667EA523129C3E00C8E190 /* ReleaseRepository.swift in Sources */,
 				5A92350A232CEF9B001E5735 /* Collaborator.swift in Sources */,

--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		5ACA090C2348836F001B4D73 /* BranchesRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */; };
 		5ACA090E23488614001B4D73 /* BranchesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090D23488614001B4D73 /* BranchesRepository.swift */; };
 		5ACA0910234886DF001B4D73 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090F234886DF001B4D73 /* Branch.swift */; };
+		5ACA091223488C65001B4D73 /* BranchDisplayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA091123488C65001B4D73 /* BranchDisplayData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -167,6 +168,7 @@
 		5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRequestClient.swift; sourceTree = "<group>"; };
 		5ACA090D23488614001B4D73 /* BranchesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRepository.swift; sourceTree = "<group>"; };
 		5ACA090F234886DF001B4D73 /* Branch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
+		5ACA091123488C65001B4D73 /* BranchDisplayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchDisplayData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -304,6 +306,7 @@
 				5A8957422308279B00A6099E /* RepositoryDisplayData.swift */,
 				5A4CBEBC2308CEAF0056E710 /* CommunityProfileDisplayData.swift */,
 				5A4CBEC02308D2240056E710 /* ReleaseDisplayData.swift */,
+				5ACA091123488C65001B4D73 /* BranchDisplayData.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -626,6 +629,7 @@
 				5A9EFC832311353300490D92 /* UISearchBarDelegateProxy.swift in Sources */,
 				5A940D1A2309349400BD0A08 /* DetailUseCase.swift in Sources */,
 				5AADA60C22EC1720001BA1AD /* APISettings.swift in Sources */,
+				5ACA091223488C65001B4D73 /* BranchDisplayData.swift in Sources */,
 				5A923504232CEF7A001E5735 /* Repository.swift in Sources */,
 				5A8957432308279B00A6099E /* RepositoryDisplayData.swift in Sources */,
 				5A662C5923083F9500BD0403 /* CollaboratorsClient.swift in Sources */,

--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		5ABB0BDF2308FE520072660A /* LoadingView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5ABB0BDE2308FE520072660A /* LoadingView.xib */; };
 		5ACA090A234880E8001B4D73 /* BranchesData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA0909234880E8001B4D73 /* BranchesData.swift */; };
 		5ACA090C2348836F001B4D73 /* BranchesRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */; };
+		5ACA090E23488614001B4D73 /* BranchesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090D23488614001B4D73 /* BranchesRepository.swift */; };
+		5ACA0910234886DF001B4D73 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090F234886DF001B4D73 /* Branch.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -163,6 +165,8 @@
 		5ABB0BDE2308FE520072660A /* LoadingView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingView.xib; sourceTree = "<group>"; };
 		5ACA0909234880E8001B4D73 /* BranchesData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesData.swift; sourceTree = "<group>"; };
 		5ACA090B2348836F001B4D73 /* BranchesRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRequestClient.swift; sourceTree = "<group>"; };
+		5ACA090D23488614001B4D73 /* BranchesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRepository.swift; sourceTree = "<group>"; };
+		5ACA090F234886DF001B4D73 /* Branch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +194,7 @@
 				5A923505232CEF86001E5735 /* Release.swift */,
 				5A923507232CEF91001E5735 /* CommunityProfile.swift */,
 				5A923509232CEF9B001E5735 /* Collaborator.swift */,
+				5ACA090F234886DF001B4D73 /* Branch.swift */,
 			);
 			path = Value;
 			sourceTree = "<group>";
@@ -222,6 +227,7 @@
 				5A667E9F2312858E00C8E190 /* CommunityProfileRepository.swift */,
 				5A667EA423129C3E00C8E190 /* ReleaseRepository.swift */,
 				5A667EA623129FF900C8E190 /* CollaboratorRepository.swift */,
+				5ACA090D23488614001B4D73 /* BranchesRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -640,6 +646,7 @@
 				5A940D18230933ED00BD0A08 /* DetailViewModel.swift in Sources */,
 				5A662C61230842BB00BD0403 /* CollaboratorData.swift in Sources */,
 				5A61EECE22EF208B00054B92 /* SearchListUseCase.swift in Sources */,
+				5ACA0910234886DF001B4D73 /* Branch.swift in Sources */,
 				5A9B912122EBEB0500996712 /* AppDelegate.swift in Sources */,
 				5A662C5323083DA700BD0403 /* DetailView.swift in Sources */,
 				5A4CBEC12308D2240056E710 /* ReleaseDisplayData.swift in Sources */,
@@ -661,6 +668,7 @@
 				5A92350A232CEF9B001E5735 /* Collaborator.swift in Sources */,
 				5A9EFC8B2312409400490D92 /* StarColor+Extension.swift in Sources */,
 				5A4CBEBD2308CEAF0056E710 /* CommunityProfileDisplayData.swift in Sources */,
+				5ACA090E23488614001B4D73 /* BranchesRepository.swift in Sources */,
 				5A9B912322EBEB0500996712 /* SceneDelegate.swift in Sources */,
 				5A61EED222EF265B00054B92 /* SearchRepository.swift in Sources */,
 				5A923508232CEF91001E5735 /* CommunityProfile.swift in Sources */,

--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		5ABAAC11231B9B9000AF76A7 /* GitHubAPIRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABAAC10231B9B9000AF76A7 /* GitHubAPIRequestable.swift */; };
 		5ABB0BDD2308FE470072660A /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABB0BDC2308FE470072660A /* LoadingView.swift */; };
 		5ABB0BDF2308FE520072660A /* LoadingView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5ABB0BDE2308FE520072660A /* LoadingView.xib */; };
+		5ACA090A234880E8001B4D73 /* BranchesData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA0909234880E8001B4D73 /* BranchesData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +160,7 @@
 		5ABAAC10231B9B9000AF76A7 /* GitHubAPIRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIRequestable.swift; sourceTree = "<group>"; };
 		5ABB0BDC2308FE470072660A /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		5ABB0BDE2308FE520072660A /* LoadingView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingView.xib; sourceTree = "<group>"; };
+		5ACA0909234880E8001B4D73 /* BranchesData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +208,7 @@
 				5A662C5E2308423800BD0403 /* CommunityProfileData.swift */,
 				5A662C60230842BB00BD0403 /* CollaboratorData.swift */,
 				5A74E1652307F20600EFEA7C /* RepositoryData.swift */,
+				5ACA0909234880E8001B4D73 /* BranchesData.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -605,6 +608,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5ACA090A234880E8001B4D73 /* BranchesData.swift in Sources */,
 				5A9EFC8823123F5500490D92 /* StarColor.swift in Sources */,
 				5A4CBEBF2308D13A0056E710 /* Date+Additions.swift in Sources */,
 				5AA7E3E22331E4690011CE1B /* CollaboratorTitleView.swift in Sources */,

--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		5AA7E3E02331E45A0011CE1B /* CollaboratorTitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AA7E3DF2331E45A0011CE1B /* CollaboratorTitleView.xib */; };
 		5AA7E3E22331E4690011CE1B /* CollaboratorTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7E3E12331E4690011CE1B /* CollaboratorTitleView.swift */; };
 		5AA7E3E423320BD00011CE1B /* DetailContributorTitleDisplayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA7E3E323320BD00011CE1B /* DetailContributorTitleDisplayData.swift */; };
+		5AA8374D237819FE00B059DC /* BranchView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AA8374C237819FE00B059DC /* BranchView.xib */; };
 		5AADA5FA22EC101A001BA1AD /* SearchListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AADA5F922EC101A001BA1AD /* SearchListView.swift */; };
 		5AADA5FE22EC105D001BA1AD /* SearchListView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AADA5FD22EC105D001BA1AD /* SearchListView.xib */; };
 		5AADA60822EC16CC001BA1AD /* SearchListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AADA60722EC16CC001BA1AD /* SearchListViewController.swift */; };
@@ -81,7 +82,6 @@
 		5ACA0910234886DF001B4D73 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090F234886DF001B4D73 /* Branch.swift */; };
 		5ACA091223488C65001B4D73 /* BranchDisplayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA091123488C65001B4D73 /* BranchDisplayData.swift */; };
 		5ACA091423488D40001B4D73 /* BranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA091323488D40001B4D73 /* BranchView.swift */; };
-		5ACA091623488D49001B4D73 /* BranchView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5ACA091523488D49001B4D73 /* BranchView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,6 +149,7 @@
 		5AA7E3DF2331E45A0011CE1B /* CollaboratorTitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollaboratorTitleView.xib; sourceTree = "<group>"; };
 		5AA7E3E12331E4690011CE1B /* CollaboratorTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollaboratorTitleView.swift; sourceTree = "<group>"; };
 		5AA7E3E323320BD00011CE1B /* DetailContributorTitleDisplayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailContributorTitleDisplayData.swift; sourceTree = "<group>"; };
+		5AA8374C237819FE00B059DC /* BranchView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BranchView.xib; sourceTree = "<group>"; };
 		5AADA5F922EC101A001BA1AD /* SearchListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListView.swift; sourceTree = "<group>"; };
 		5AADA5FD22EC105D001BA1AD /* SearchListView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchListView.xib; sourceTree = "<group>"; };
 		5AADA60722EC16CC001BA1AD /* SearchListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListViewController.swift; sourceTree = "<group>"; };
@@ -172,7 +173,6 @@
 		5ACA090F234886DF001B4D73 /* Branch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
 		5ACA091123488C65001B4D73 /* BranchDisplayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchDisplayData.swift; sourceTree = "<group>"; };
 		5ACA091323488D40001B4D73 /* BranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchView.swift; sourceTree = "<group>"; };
-		5ACA091523488D49001B4D73 /* BranchView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BranchView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,7 +266,7 @@
 				5AA7E3DF2331E45A0011CE1B /* CollaboratorTitleView.xib */,
 				5AA7E3E12331E4690011CE1B /* CollaboratorTitleView.swift */,
 				5ACA091323488D40001B4D73 /* BranchView.swift */,
-				5ACA091523488D49001B4D73 /* BranchView.xib */,
+				5AA8374C237819FE00B059DC /* BranchView.xib */,
 			);
 			path = RepositoryDetail;
 			sourceTree = "<group>";
@@ -597,7 +597,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5ACA091623488D49001B4D73 /* BranchView.xib in Resources */,
+				5AA8374D237819FE00B059DC /* BranchView.xib in Resources */,
 				5AB6D67422F59D46008C3D14 /* LoadingCell.xib in Resources */,
 				5A9B912D22EBEB0600996712 /* LaunchScreen.storyboard in Resources */,
 				5A4CBEC72308D7F70056E710 /* CommunityProfileView.xib in Resources */,

--- a/iOSLayeredSample.xcodeproj/project.pbxproj
+++ b/iOSLayeredSample.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		5ACA090E23488614001B4D73 /* BranchesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090D23488614001B4D73 /* BranchesRepository.swift */; };
 		5ACA0910234886DF001B4D73 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA090F234886DF001B4D73 /* Branch.swift */; };
 		5ACA091223488C65001B4D73 /* BranchDisplayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA091123488C65001B4D73 /* BranchDisplayData.swift */; };
+		5ACA091423488D40001B4D73 /* BranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA091323488D40001B4D73 /* BranchView.swift */; };
+		5ACA091623488D49001B4D73 /* BranchView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5ACA091523488D49001B4D73 /* BranchView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -169,6 +171,8 @@
 		5ACA090D23488614001B4D73 /* BranchesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchesRepository.swift; sourceTree = "<group>"; };
 		5ACA090F234886DF001B4D73 /* Branch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
 		5ACA091123488C65001B4D73 /* BranchDisplayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchDisplayData.swift; sourceTree = "<group>"; };
+		5ACA091323488D40001B4D73 /* BranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchView.swift; sourceTree = "<group>"; };
+		5ACA091523488D49001B4D73 /* BranchView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BranchView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -261,6 +265,8 @@
 				5A4CBECE2308E94F0056E710 /* CollaboratorView.swift */,
 				5AA7E3DF2331E45A0011CE1B /* CollaboratorTitleView.xib */,
 				5AA7E3E12331E4690011CE1B /* CollaboratorTitleView.swift */,
+				5ACA091323488D40001B4D73 /* BranchView.swift */,
+				5ACA091523488D49001B4D73 /* BranchView.xib */,
 			);
 			path = RepositoryDetail;
 			sourceTree = "<group>";
@@ -591,6 +597,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5ACA091623488D49001B4D73 /* BranchView.xib in Resources */,
 				5AB6D67422F59D46008C3D14 /* LoadingCell.xib in Resources */,
 				5A9B912D22EBEB0600996712 /* LaunchScreen.storyboard in Resources */,
 				5A4CBEC72308D7F70056E710 /* CommunityProfileView.xib in Resources */,
@@ -668,6 +675,7 @@
 				5AADA61C22EC1F47001BA1AD /* NSObject+Additions.swift in Sources */,
 				5ACA090C2348836F001B4D73 /* BranchesRequestClient.swift in Sources */,
 				5A667EA723129FF900C8E190 /* CollaboratorRepository.swift in Sources */,
+				5ACA091423488D40001B4D73 /* BranchView.swift in Sources */,
 				5A667EA523129C3E00C8E190 /* ReleaseRepository.swift in Sources */,
 				5A92350A232CEF9B001E5735 /* Collaborator.swift in Sources */,
 				5A9EFC8B2312409400490D92 /* StarColor+Extension.swift in Sources */,

--- a/iOSLayeredSample/Application/Detail/DetailViewModel.swift
+++ b/iOSLayeredSample/Application/Detail/DetailViewModel.swift
@@ -40,7 +40,7 @@ final class DetailViewModel: DetailViewModelProtocol {
         status.value = .loading
         let publishers = useCase.reload(repository: repositoryFullName)
         otherModulesCancellable = publishers.otherModules.sink(receiveValue: { [weak self] others in
-            self?.didLoad(latestRelease: others.0, collaborators: others.1)
+            self?.didLoad(latestRelease: others.0, collaborators: others.1, branches: others.2)
         })
         
         profileCancellable = publishers.profile.sink(receiveCompletion: { [weak self] result in
@@ -58,8 +58,13 @@ final class DetailViewModel: DetailViewModelProtocol {
 }
 
 extension DetailViewModel {
-    func didLoad(latestRelease: Release?, collaborators: [Collaborator]) {
+    func didLoad(latestRelease: Release?, collaborators: [Collaborator], branches: [Branch]) {
         var filterd = contents.value.filter { !($0 is LoadingDisplayData) }
+        
+        if let first = branches.first {
+            filterd.append(BranchDisplayData(with: first))
+        }
+        
         if let release = latestRelease {
             filterd.append(ReleaseDisplayData(with: release, status: ReleaseStatus(isDraft: release.isDraft, isPrerelease: release.isPreRelease)))
         }
@@ -68,6 +73,7 @@ extension DetailViewModel {
             let filterdCollaborators = collaborators.prefix(displayCollaboratorsCount)
             filterd.append(CollaboratorsDisplayData(with: Array(filterdCollaborators)))
         }
+        
         contents.value = filterd
     }
     

--- a/iOSLayeredSample/Application/DisplayData/Repository/BranchDisplayData.swift
+++ b/iOSLayeredSample/Application/DisplayData/Repository/BranchDisplayData.swift
@@ -1,0 +1,19 @@
+//
+//  BranchDisplayData.swift
+//  iOSLayeredSample
+//
+//  Created by rnishimu on 2019/10/05.
+//  Copyright © 2019 rnishimu22001. All rights reserved.
+//
+
+struct BranchDisplayData {
+    let name: String
+    let isProtected: Bool
+}
+
+extension BranchDisplayData {
+    init(with branch: Branch) {
+        self.name = branch.name
+        self.isProtected = branch.isProtected
+    }
+}

--- a/iOSLayeredSample/Application/DisplayData/Repository/BranchDisplayData.swift
+++ b/iOSLayeredSample/Application/DisplayData/Repository/BranchDisplayData.swift
@@ -8,12 +8,12 @@
 
 struct BranchDisplayData {
     let name: String
-    let isProtected: Bool
+    let shouldHiddenProtected: Bool
 }
 
 extension BranchDisplayData {
     init(with branch: Branch) {
         self.name = branch.name
-        self.isProtected = branch.isProtected
+        self.shouldHiddenProtected = !branch.isProtected
     }
 }

--- a/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
+++ b/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol BranchesRequestClientProtocol {
-    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<Branches, Error>, GitHubAPIResponseHeader?) -> Void))
+    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<BranchesData, Error>, GitHubAPIResponseHeader?) -> Void))
 }
 
 struct BranchesRequestClient: BranchesRequestClientProtocol, GitHubAPIRequestable {
@@ -19,7 +19,7 @@ struct BranchesRequestClient: BranchesRequestClientProtocol, GitHubAPIRequestabl
         self.requester = requester
     }
     
-    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<Branches, Error>, GitHubAPIResponseHeader?) -> Void)) {
+    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<BranchesData, Error>, GitHubAPIResponseHeader?) -> Void)) {
         guard var urlComponents = URLComponents(string: APIURLSetting.BranchList.url(with: fullName)) else {
             completion(.failure(RequestError.badURL), nil)
             return

--- a/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
+++ b/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
@@ -1,0 +1,36 @@
+//
+//  BranchesRequestClient.swift
+//  iOSLayeredSample
+//
+//  Created by rnishimu on 2019/10/05.
+//  Copyright © 2019 rnishimu22001. All rights reserved.
+//
+
+import Foundation
+
+protocol BranchesRequestClientProtocol {
+    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<Branches, Error>, GitHubAPIResponseHeader?) -> Void))
+}
+
+struct BranchesRequestClient: BranchesRequestClientProtocol, GitHubAPIRequestable {
+    let requester: HTTPRequestable
+    
+    init(requester: HTTPRequestable = HTTPRequester()) {
+        self.requester = requester
+    }
+    
+    func requestBranch(inRepository fullName: String, completion: @escaping ((Result<Branches, Error>, GitHubAPIResponseHeader?) -> Void)) {
+        guard var urlComponents = URLComponents(string: APIURLSetting.BranchList.url(with: fullName)) else {
+            completion(.failure(RequestError.badURL), nil)
+            return
+        }
+        let query = URLQueryItem(name: "protected", value: "true")
+        urlComponents.queryItems = [query]
+        guard let url = urlComponents.url else {
+            completion(.failure(RequestError.badURL), nil)
+            return
+        }
+        let request = URLRequest(url: url)
+        self.request(request, completion: completion)
+    }
+}

--- a/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
+++ b/iOSLayeredSample/DataLayer/APIRequestClient/BranchesRequestClient.swift
@@ -20,12 +20,10 @@ struct BranchesRequestClient: BranchesRequestClientProtocol, GitHubAPIRequestabl
     }
     
     func requestBranch(inRepository fullName: String, completion: @escaping ((Result<BranchesData, Error>, GitHubAPIResponseHeader?) -> Void)) {
-        guard var urlComponents = URLComponents(string: APIURLSetting.BranchList.url(with: fullName)) else {
+        guard let urlComponents = URLComponents(string: APIURLSetting.BranchList.url(with: fullName)) else {
             completion(.failure(RequestError.badURL), nil)
             return
         }
-        let query = URLQueryItem(name: "protected", value: "true")
-        urlComponents.queryItems = [query]
         guard let url = urlComponents.url else {
             completion(.failure(RequestError.badURL), nil)
             return

--- a/iOSLayeredSample/DataLayer/APIRequestClient/GitHubAPIRequestable.swift
+++ b/iOSLayeredSample/DataLayer/APIRequestClient/GitHubAPIRequestable.swift
@@ -27,8 +27,8 @@ extension GitHubAPIRequestable {
                 do {
                     let profile = try JSONDecoder().decode(T.self, from: data)
                     completion(.success(profile), header)
-                } catch {
-                    completion(.failure(RequestError.dataEncodeFailed), header)
+                } catch(let error) {
+                    completion(.failure(error), header)
                 }
             }
         }

--- a/iOSLayeredSample/DataLayer/Data/BranchesData.swift
+++ b/iOSLayeredSample/DataLayer/Data/BranchesData.swift
@@ -1,0 +1,57 @@
+//
+//  BranchesData.swift
+//  iOSLayeredSample
+//
+//  Created by rnishimu on 2019/10/05.
+//  Copyright © 2019 rnishimu22001. All rights reserved.
+//
+// This file was generated from JSON Schema using quicktype, do not modify it directly.
+// To parse the JSON, add this file to your project and do:
+//
+//   let branches = try? newJSONDecoder().decode(Branches.self, from: jsonData)
+
+import Foundation
+
+// MARK: - Branch
+struct Branch: Codable {
+    let name: String
+    let commit: Commit
+    let protected: Bool
+    let protection: Protection
+    let protectionURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case name, commit, protected, protection
+        case protectionURL = "protection_url"
+    }
+}
+
+// MARK: - Commit
+struct Commit: Codable {
+    let sha: String
+    let url: String
+}
+
+// MARK: - Protection
+struct Protection: Codable {
+    let enabled: Bool
+    let requiredStatusChecks: RequiredStatusChecks
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case requiredStatusChecks = "required_status_checks"
+    }
+}
+
+// MARK: - RequiredStatusChecks
+struct RequiredStatusChecks: Codable {
+    let enforcementLevel: String
+    let contexts: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case enforcementLevel = "enforcement_level"
+        case contexts
+    }
+}
+
+typealias Branches = [Branch]

--- a/iOSLayeredSample/DataLayer/Data/BranchesData.swift
+++ b/iOSLayeredSample/DataLayer/Data/BranchesData.swift
@@ -17,8 +17,8 @@ struct BranchData: Codable {
     let name: String
     let commit: Commit
     let protected: Bool
-    let protection: Protection
-    let protectionURL: String
+    let protection: Protection?
+    let protectionURL: String?
 
     enum CodingKeys: String, CodingKey {
         case name, commit, protected, protection

--- a/iOSLayeredSample/DataLayer/Data/BranchesData.swift
+++ b/iOSLayeredSample/DataLayer/Data/BranchesData.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 // MARK: - Branch
-struct Branch: Codable {
+struct BranchData: Codable {
     let name: String
     let commit: Commit
     let protected: Bool
@@ -23,6 +23,12 @@ struct Branch: Codable {
     enum CodingKeys: String, CodingKey {
         case name, commit, protected, protection
         case protectionURL = "protection_url"
+    }
+}
+
+extension BranchData {
+    var converted: Branch {
+        return Branch(name: self.name, isProtected: self.protected)
     }
 }
 
@@ -54,4 +60,4 @@ struct RequiredStatusChecks: Codable {
     }
 }
 
-typealias Branches = [Branch]
+typealias BranchesData = [BranchData]

--- a/iOSLayeredSample/DataLayer/Repository/BranchesRepository.swift
+++ b/iOSLayeredSample/DataLayer/Repository/BranchesRepository.swift
@@ -1,0 +1,38 @@
+//
+//  BranchesRepository.swift
+//  iOSLayeredSample
+//
+//  Created by rnishimu on 2019/10/05.
+//  Copyright © 2019 rnishimu22001. All rights reserved.
+//
+
+import Combine
+
+protocol BranchesRepositoryProtocol {
+    func reloadBranches(inRepositoy fullName: String) -> PassthroughSubject<[Branch], Error>
+}
+
+struct BranchesRepository: BranchesRepositoryProtocol {
+    private let client: BranchesRequestClientProtocol
+    
+    init(client: BranchesRequestClientProtocol = BranchesRequestClient()) {
+        self.client = client
+    }
+    
+    func reloadBranches(inRepositoy fullName: String) -> PassthroughSubject<[Branch], Error> {
+        
+        let subject = PassthroughSubject<[Branch], Error>()
+
+        self.client.requestBranch(inRepository: fullName) { result, _ in
+            switch result {
+            case .success(let branchList):
+                let branches = branchList.map { $0.converted }
+                subject.send(branches)
+                subject.send(completion: .finished)
+            case .failure(let error):
+                subject.send(completion: .failure(error))
+            }
+        }
+        return subject
+    }
+}

--- a/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
+++ b/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
@@ -22,14 +22,17 @@ final class DetailUseCase: DetailUseCaseProtocol {
    
     let profileRepository: CommunityProfileRepositoryProtocol
     let releaseRepository: ReleaseRepositoryProtocol
-    let collaboratorRepository: CollaboratorRepository
-    
+    let collaboratorRepository: CollaboratorRepositoryProtocol
+    let branchRepository: BranchesRepositoryProtocol
+
     init(profileRepository: CommunityProfileRepositoryProtocol = CommunityProfileRepository(),
          releaseRepository: ReleaseRepositoryProtocol = ReleaseRepository(),
-         collaboratorRepository: CollaboratorRepository = CollaboratorRepository()) {
+         collaboratorRepository: CollaboratorRepositoryProtocol = CollaboratorRepository(),
+         branchRepository: BranchesRepositoryProtocol = BranchesRepository()) {
         self.profileRepository = profileRepository
         self.releaseRepository = releaseRepository
         self.collaboratorRepository = collaboratorRepository
+        self.branchRepository = branchRepository
     }
     
     func reload(repository fullName: String) ->

--- a/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
+++ b/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
@@ -13,7 +13,7 @@ protocol DetailUseCaseProtocol {
     /// ページの再読み込み時に呼ばれる
     func reload(repository fullName: String) ->
         (profile: PassthroughSubject<CommunityProfile, Error>,
-        otherModules: Publishers.Zip<Publishers.Catch<Publishers.Map<PassthroughSubject<Release, Error>, Release?>, Just<Release?>>, Publishers.Catch<PassthroughSubject<[Collaborator], Error>, Just<[Collaborator]>>>)
+        otherModules: Publishers.Zip3<Publishers.Catch<Publishers.Map<PassthroughSubject<Release, Error>, Release?>, Just<Release?>>, Publishers.Catch<PassthroughSubject<[Collaborator], Error>, Just<[Collaborator]>>, Publishers.Catch<PassthroughSubject<[Branch], Error>, Just<[Branch]>>>)
 }
 
 final class DetailUseCase: DetailUseCaseProtocol {
@@ -37,7 +37,7 @@ final class DetailUseCase: DetailUseCaseProtocol {
     
     func reload(repository fullName: String) ->
         (profile: PassthroughSubject<CommunityProfile, Error>,
-        otherModules: Publishers.Zip<Publishers.Catch<Publishers.Map<PassthroughSubject<Release, Error>, Release?>, Just<Release?>>, Publishers.Catch<PassthroughSubject<[Collaborator], Error>, Just<[Collaborator]>>>) {
+        otherModules: Publishers.Zip3<Publishers.Catch<Publishers.Map<PassthroughSubject<Release, Error>, Release?>, Just<Release?>>, Publishers.Catch<PassthroughSubject<[Collaborator], Error>, Just<[Collaborator]>>, Publishers.Catch<PassthroughSubject<[Branch], Error>, Just<[Branch]>>>) {
        
         let profileSubject = profileRepository.reload(repository: fullName)
             let releaseSubject = releaseRepository.reloadLatestRelease(repository: fullName).map({ (release) -> Release? in
@@ -49,7 +49,12 @@ final class DetailUseCase: DetailUseCaseProtocol {
             let collaboratorSubject = collaboratorRepository.reload(repositoy: fullName).catch({ (_) -> Just<[Collaborator]> in
                 return Just([])
             })
-        let otherModulesSubject =  releaseSubject.zip(collaboratorSubject)
+            
+            let branchesSubject = branchRepository.reloadBranches(inRepositoy: fullName).catch({ (_) -> Just<[Branch]> in
+                return Just([])
+            })
+            
+            let otherModulesSubject =  releaseSubject.zip(collaboratorSubject, branchesSubject)
             
         return (profile: profileSubject, otherModules: otherModulesSubject)
     }

--- a/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
+++ b/iOSLayeredSample/DomainLayer/UseCase/DetailUseCase.swift
@@ -40,6 +40,7 @@ final class DetailUseCase: DetailUseCaseProtocol {
         otherModules: Publishers.Zip3<Publishers.Catch<Publishers.Map<PassthroughSubject<Release, Error>, Release?>, Just<Release?>>, Publishers.Catch<PassthroughSubject<[Collaborator], Error>, Just<[Collaborator]>>, Publishers.Catch<PassthroughSubject<[Branch], Error>, Just<[Branch]>>>) {
        
         let profileSubject = profileRepository.reload(repository: fullName)
+           
             let releaseSubject = releaseRepository.reloadLatestRelease(repository: fullName).map({ (release) -> Release? in
                 return release
             }).catch({ (_) -> Just<Release?> in

--- a/iOSLayeredSample/DomainLayer/Value/Branch.swift
+++ b/iOSLayeredSample/DomainLayer/Value/Branch.swift
@@ -1,0 +1,12 @@
+//
+//  Branch.swift
+//  iOSLayeredSample
+//
+//  Created by rnishimu on 2019/10/05.
+//  Copyright © 2019 rnishimu22001. All rights reserved.
+//
+
+struct Branch {
+    let name: String
+    let isProtected: Bool
+}

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
@@ -1,22 +1,20 @@
 //
-//  CollaboratorView.swift
+//  BranchView.swift
 //  iOSLayeredSample
 //
-//  Created by rnishimu on 2019/08/18.
+//  Created by rnishimu on 2019/10/05.
 //  Copyright © 2019 rnishimu22001. All rights reserved.
 //
 
 import UIKit
-import Nuke
 
-final class CollaboratorView: UIView {
+final class BranchView: UIView {
     
-    static let height: CGFloat = 100
+    static let height: CGFloat = 20
     
     @IBOutlet var view: UIView!
-    @IBOutlet weak var icon: UIImageView!
     @IBOutlet weak var name: UILabel!
-    @IBOutlet weak var admin: UILabel!
+    @IBOutlet weak var protected: UILabel!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -34,9 +32,8 @@ final class CollaboratorView: UIView {
         view.frame = self.frame
     }
     
-    func setup(_ colloaborator: CollaboratorDisplayData) {
-        Nuke.loadImage(with: colloaborator.icon, into: icon)
-        name.text = colloaborator.name
-        admin.isHidden = !colloaborator.hasAdminBadge
+    func setup(_ branch: BranchDisplayData) {
+        name.text = branch.name
+        protected.isHidden = branch.shouldHiddenProtected
     }
 }

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
@@ -14,7 +14,7 @@ final class BranchView: UIView {
     
     @IBOutlet var view: UIView!
     @IBOutlet weak var name: UILabel!
-    @IBOutlet weak var protected: UILabel!
+    @IBOutlet weak var protected: UIView!
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class BranchView: UIView {
     
-    static let height: CGFloat = 20
+    static let height: CGFloat = 30
     
     @IBOutlet var view: UIView!
     @IBOutlet weak var name: UILabel!

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
@@ -54,15 +54,26 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZXc-wV-de6" userLabel="Separator">
+                    <rect key="frame" x="8" y="468.5" width="398" height="0.5"/>
+                    <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="0.5" id="f7u-29-vW3"/>
+                    </constraints>
+                    <viewLayoutGuide key="safeArea" id="hIz-eh-gPv"/>
+                </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
+                <constraint firstItem="ZXc-wV-de6" firstAttribute="leading" secondItem="Aqm-ps-7JU" secondAttribute="leading" constant="8" id="H8e-ZP-X6h"/>
                 <constraint firstItem="qKh-rz-y28" firstAttribute="leading" secondItem="voQ-Wu-HeE" secondAttribute="trailing" constant="12" id="J11-5f-zVc"/>
                 <constraint firstItem="voQ-Wu-HeE" firstAttribute="leading" secondItem="Aqm-ps-7JU" secondAttribute="leading" constant="12" id="Mcm-dk-zpo"/>
                 <constraint firstItem="qKh-rz-y28" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="NX4-Zs-Pdt"/>
                 <constraint firstItem="dTd-UH-xqz" firstAttribute="leading" secondItem="qKh-rz-y28" secondAttribute="trailing" constant="8" id="WY2-OO-phG"/>
                 <constraint firstItem="voQ-Wu-HeE" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="YAO-ZW-8En"/>
                 <constraint firstItem="dTd-UH-xqz" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="ZeO-70-cUE"/>
+                <constraint firstItem="ZXc-wV-de6" firstAttribute="bottom" secondItem="Aqm-ps-7JU" secondAttribute="bottom" id="uZI-5e-FFs"/>
+                <constraint firstItem="Aqm-ps-7JU" firstAttribute="trailing" secondItem="ZXc-wV-de6" secondAttribute="trailing" constant="8" id="y4R-U3-vjj"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="Aqm-ps-7JU"/>

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BranchView" customModule="iOSLayeredSample" customModuleProvider="target">
+            <connections>
+                <outlet property="name" destination="Kux-CJ-HqV" id="mPz-5S-UR4"/>
+                <outlet property="protected" destination="HAQ-Ur-rON" id="9Az-gg-4m6"/>
+                <outlet property="view" destination="8ji-Ah-xR5" id="N6U-ds-dqf"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="8ji-Ah-xR5">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="231"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UoQ-xh-Gad">
+                    <rect key="frame" x="87" y="73" width="240" height="127"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BranchName:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rxM-cQ-f9q">
+                            <rect key="frame" x="0.0" y="0.0" width="85" height="127"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kux-CJ-HqV">
+                            <rect key="frame" x="93" y="53" width="53" height="21"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="rxM-cQ-f9q" secondAttribute="bottom" id="Ak3-Ic-El6"/>
+                        <constraint firstItem="rxM-cQ-f9q" firstAttribute="top" secondItem="UoQ-xh-Gad" secondAttribute="top" id="YIC-fw-QAq"/>
+                        <constraint firstItem="rxM-cQ-f9q" firstAttribute="leading" secondItem="UoQ-xh-Gad" secondAttribute="leading" id="jq1-Nn-7bk"/>
+                        <constraint firstItem="Kux-CJ-HqV" firstAttribute="leading" secondItem="rxM-cQ-f9q" secondAttribute="trailing" constant="8" id="jvO-yr-wKR"/>
+                        <constraint firstItem="Kux-CJ-HqV" firstAttribute="centerY" secondItem="rxM-cQ-f9q" secondAttribute="centerY" id="uho-ic-3iw"/>
+                    </constraints>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HAQ-Ur-rON">
+                    <rect key="frame" x="197" y="126" width="90" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="UoQ-xh-Gad" firstAttribute="leading" secondItem="6yH-QW-soE" secondAttribute="leading" constant="12" id="0IO-wl-hsL"/>
+                <constraint firstItem="UoQ-xh-Gad" firstAttribute="centerY" secondItem="6yH-QW-soE" secondAttribute="centerY" id="G9p-QR-Utj"/>
+                <constraint firstItem="HAQ-Ur-rON" firstAttribute="centerY" secondItem="UoQ-xh-Gad" secondAttribute="centerY" id="UlH-vJ-2aw"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="6yH-QW-soE"/>
+            <point key="canvasLocation" x="-304.34782608695656" y="-173.77232142857142"/>
+        </view>
+    </objects>
+</document>

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/BranchView.xib
@@ -1,69 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BranchView" customModule="iOSLayeredSample" customModuleProvider="target">
             <connections>
-                <outlet property="name" destination="Kux-CJ-HqV" id="mPz-5S-UR4"/>
-                <outlet property="protected" destination="HAQ-Ur-rON" id="9Az-gg-4m6"/>
-                <outlet property="view" destination="8ji-Ah-xR5" id="N6U-ds-dqf"/>
+                <outlet property="name" destination="qKh-rz-y28" id="EUO-MG-TkS"/>
+                <outlet property="protected" destination="dTd-UH-xqz" id="LgQ-EL-7lz"/>
+                <outlet property="view" destination="ckX-ut-h9i" id="PSw-X8-OJu"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="8ji-Ah-xR5">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="231"/>
+        <view contentMode="scaleToFill" id="ckX-ut-h9i">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="469"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UoQ-xh-Gad">
-                    <rect key="frame" x="87" y="73" width="240" height="127"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BranchName:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="voQ-Wu-HeE">
+                    <rect key="frame" x="12" y="246" width="104" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qKh-rz-y28">
+                    <rect key="frame" x="128" y="246" width="42" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dTd-UH-xqz">
+                    <rect key="frame" x="178" y="244" width="79" height="25"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BranchName:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rxM-cQ-f9q">
-                            <rect key="frame" x="0.0" y="0.0" width="85" height="127"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="protected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3e8-JK-GjG">
+                            <rect key="frame" x="2" y="2" width="75" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kux-CJ-HqV">
-                            <rect key="frame" x="93" y="53" width="53" height="21"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                            <nil key="textColor"/>
+                            <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="rxM-cQ-f9q" secondAttribute="bottom" id="Ak3-Ic-El6"/>
-                        <constraint firstItem="rxM-cQ-f9q" firstAttribute="top" secondItem="UoQ-xh-Gad" secondAttribute="top" id="YIC-fw-QAq"/>
-                        <constraint firstItem="rxM-cQ-f9q" firstAttribute="leading" secondItem="UoQ-xh-Gad" secondAttribute="leading" id="jq1-Nn-7bk"/>
-                        <constraint firstItem="Kux-CJ-HqV" firstAttribute="leading" secondItem="rxM-cQ-f9q" secondAttribute="trailing" constant="8" id="jvO-yr-wKR"/>
-                        <constraint firstItem="Kux-CJ-HqV" firstAttribute="centerY" secondItem="rxM-cQ-f9q" secondAttribute="centerY" id="uho-ic-3iw"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HAQ-Ur-rON">
-                    <rect key="frame" x="197" y="126" width="90" height="21"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <rect key="contentStretch" x="1" y="1" width="1" height="1"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                    <constraints>
+                        <constraint firstItem="3e8-JK-GjG" firstAttribute="leading" secondItem="dTd-UH-xqz" secondAttribute="leading" constant="2" id="7xJ-8s-SMw"/>
+                        <constraint firstAttribute="trailing" secondItem="3e8-JK-GjG" secondAttribute="trailing" constant="2" id="E7i-HP-MZc"/>
+                        <constraint firstItem="3e8-JK-GjG" firstAttribute="top" secondItem="dTd-UH-xqz" secondAttribute="top" constant="2" id="jfr-IK-zPB"/>
+                        <constraint firstAttribute="bottom" secondItem="3e8-JK-GjG" secondAttribute="bottom" constant="2" id="l9d-hw-6ug"/>
+                    </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="2"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="UoQ-xh-Gad" firstAttribute="leading" secondItem="6yH-QW-soE" secondAttribute="leading" constant="12" id="0IO-wl-hsL"/>
-                <constraint firstItem="UoQ-xh-Gad" firstAttribute="centerY" secondItem="6yH-QW-soE" secondAttribute="centerY" id="G9p-QR-Utj"/>
-                <constraint firstItem="HAQ-Ur-rON" firstAttribute="centerY" secondItem="UoQ-xh-Gad" secondAttribute="centerY" id="UlH-vJ-2aw"/>
+                <constraint firstItem="qKh-rz-y28" firstAttribute="leading" secondItem="voQ-Wu-HeE" secondAttribute="trailing" constant="12" id="J11-5f-zVc"/>
+                <constraint firstItem="voQ-Wu-HeE" firstAttribute="leading" secondItem="Aqm-ps-7JU" secondAttribute="leading" constant="12" id="Mcm-dk-zpo"/>
+                <constraint firstItem="qKh-rz-y28" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="NX4-Zs-Pdt"/>
+                <constraint firstItem="dTd-UH-xqz" firstAttribute="leading" secondItem="qKh-rz-y28" secondAttribute="trailing" constant="8" id="WY2-OO-phG"/>
+                <constraint firstItem="voQ-Wu-HeE" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="YAO-ZW-8En"/>
+                <constraint firstItem="dTd-UH-xqz" firstAttribute="centerY" secondItem="Aqm-ps-7JU" secondAttribute="centerY" id="ZeO-70-cUE"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="6yH-QW-soE"/>
-            <point key="canvasLocation" x="-304.34782608695656" y="-173.77232142857142"/>
+            <viewLayoutGuide key="safeArea" id="Aqm-ps-7JU"/>
+            <point key="canvasLocation" x="113.04347826086958" y="301.67410714285711"/>
         </view>
     </objects>
 </document>

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/DetailView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/DetailView.swift
@@ -72,6 +72,7 @@ final class DetailPresenter: NSObject, DetailViewProtocol {
             addContentView(for: release)
         case let collaborators as CollaboratorsDisplayData:
             addContentView(for: collaborators)
+        case let
         case is DetailContributorTitleDisplayData:
             // add title
             let size = CGSize(width: contentsView.frame.size.width, height: CollaboratorTitleView.height)

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/DetailView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/DetailView.swift
@@ -72,7 +72,8 @@ final class DetailPresenter: NSObject, DetailViewProtocol {
             addContentView(for: release)
         case let collaborators as CollaboratorsDisplayData:
             addContentView(for: collaborators)
-        case let
+        case let branch as BranchDisplayData:
+            addContentView(for: branch)
         case is DetailContributorTitleDisplayData:
             // add title
             let size = CGSize(width: contentsView.frame.size.width, height: CollaboratorTitleView.height)
@@ -119,5 +120,17 @@ final class DetailPresenter: NSObject, DetailViewProtocol {
             collaboratorView.heightAnchor.constraint(equalToConstant: CollaboratorView.height).isActive = true
             contentsView.addArrangedSubview(collaboratorView)
         }
+    }
+    
+    private func addContentView(for branch: BranchDisplayData) {
+        // add branch
+
+        let size = CGSize(width: contentsView.frame.size.width, height: BranchView.height)
+        let frame = CGRect(origin: .zero, size: size)
+        let branchView = BranchView(frame: frame)
+        branchView.setup(branch)
+        branchView.heightAnchor.constraint(equalToConstant: BranchView.height).isActive = true
+        contentsView.addArrangedSubview(branchView)
+        
     }
 }

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/ReleaseView.swift
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/ReleaseView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class ReleaseView: UIView {
     
-    static let height: CGFloat = 60
+    static let height: CGFloat = 50
     
     @IBOutlet var view: UIView!
     @IBOutlet weak var tagName: UILabel!

--- a/iOSLayeredSample/PresentationLayer/RepositoryDetail/ReleaseView.xib
+++ b/iOSLayeredSample/PresentationLayer/RepositoryDetail/ReleaseView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -44,7 +44,7 @@
                                     <rect key="frame" x="2" y="0.0" width="31" height="14.5"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>

--- a/iOSLayeredSample/Resources/Settings/APISettings.swift
+++ b/iOSLayeredSample/Resources/Settings/APISettings.swift
@@ -30,6 +30,12 @@ struct APIURLSetting {
         }
     }
     
+    struct BranchList {
+        static func url(with fullName: String) -> String {
+            return base + "repos/" + fullName + "/branches"
+        }
+    }
+    
     struct Collaborators {
         
         static func url(with fullName: String) -> String {


### PR DESCRIPTION
## 概要

Githubのリポジトリ情報の詳細画面にブランチ情報の表示を追加しました。

## 期待値

* ブランチ情報を取得できた場合はAPIから取得できた一番最初のブランチをリポジトリ情報詳細画面に表示
* ブランチ情報を取得できた場合はリポジトリ情報詳細画面に表示しない
* ブランチ情報の取得はリリース情報と同一のタイミングで取得する
* ブランチ情報が取得できた場合はリリース情報の上に表示する

## UIに対する変更

| 変更前 | 変更後 |
|---|---|
|<img width="375" alt="スクリーンショット 2019-11-10 19 33 00" src="https://user-images.githubusercontent.com/25366111/68542579-78635980-03f1-11ea-96a6-b3b979e7a110.png"> | <img width="367" alt="スクリーンショット 2019-11-10 19 31 51" src="https://user-images.githubusercontent.com/25366111/68542583-81542b00-03f1-11ea-9fcc-c552e12c59c3.png"> |

## コード変更の概要

| 変更した層 |変更内容 |
|---|---|
| PresentationLayer | ブランチ情報を表示するためのView、BranchViewのクラスを追加 |
| ApplicationLayer | DetailViewModelで表示コンテンツ整形時にリリース情報の前にブランチ情報を追加 |
| DomainLayer |  DetailUseCaseでリリース情報とブランチ情報の取得を待ち合わせ  |
| DataLayer | ブランチ情報をAPIにリクエストするためのClientとRepositoryを追加 |